### PR TITLE
Refactor for non-blocking sockets

### DIFF
--- a/TouchPortal-API/TouchPortalAPI/__init__.py
+++ b/TouchPortal-API/TouchPortalAPI/__init__.py
@@ -1,7 +1,8 @@
 import socket
+import selectors
 import json
 from pyee import EventEmitter
-from threading import Timer
+from threading import Timer, Event, Lock
 import requests
 import os
 import base64
@@ -20,40 +21,84 @@ class TYPES:
 class Client(EventEmitter):
     TPHOST = '127.0.0.1'
     TPPORT = 12136
+    RCV_BUFFER_SZ = 4096   # [B] incoming data buffer size
+    SND_BUFFER_SZ = 32**4  # [B] maximum size of send data buffer (1MB)
+    SLEEP_PERIOD = 0.01    # [s] event loop sleep between socket read events
+    SOCK_EVENT_TO = 1.0    # [s] timeout for selector.select() event monitor
 
     def __init__(self, pluginId):
         super().__init__()
         self.pluginId = pluginId
-        self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.client = None
+        self.selector = None
         self.currentStates = {}
         self.currentSettings = {}
-        self.__running = False
         self.__heldActions = {}
+        self.__stopEvent = Event()       # main loop inerrupt
+        self.__stopEvent.set()           # not running yet
+        self.__dataReadyEvent = Event()  # set when __sendBuffer has data
+        self.__writeLock = Lock()        # mutex for __sendBuffer
+        self.__sendBuffer = bytearray()
+        self.__recvBuffer = bytearray()
 
-    def __buffered_readLine(self, socket):
-        line = bytearray()
-        while True:
-            part = self.client.recv(1)
-            if part != b'\n':
-                line.extend(part)
-            else:
-                break
-        return line
-
-    def __parseReceiveData(self):
+    def __buffered_readLine(self):
         try:
-            rxData = self.__buffered_readLine(self.client)
-            if self.__onReceiveCallback:
-                Timer(0, self.__onReceiveCallback, args=[rxData]).start()
-                Timer(0, self.__onAllMessage, args=[rxData]).start()
-            if self.__running:
-                self.__parseReceiveData()
+            # Should be ready to read
+            data = self.client.recv(self.RCV_BUFFER_SZ)
+        except BlockingIOError:
+            pass  # Resource temporarily unavailable (errno EWOULDBLOCK)
+        except OSError:
+            raise  # No connection
+        else:
+            if data:
+                lines = []
+                self.__recvBuffer += data
+                while (i := self.__recvBuffer.find(b'\n')) > -1:
+                    lines.append(self.__recvBuffer[:i])
+                    del self.__recvBuffer[:i+1]
+                return lines
+            else:
+                # No connection
+                raise RuntimeError("Peer closed the connection.")
+        return []
 
+    def __write(self):
+        if self.client and self.__sendBuffer and self.__getWriteLock():
+            try:
+                # Should be ready to write
+                sent = self.client.send(self.__sendBuffer)
+            except BlockingIOError:
+                pass  # Resource temporarily unavailable (errno EWOULDBLOCK)
+            except OSError:
+                raise  # No connection
+            else:
+                del self.__sendBuffer[:sent]
+            finally:
+                if not self.__sendBuffer:
+                    self.__dataReadyEvent.clear()
+                self.__writeLock.release()
+
+    def __run(self):
+        try:
+            while not self.__stopEvent.is_set():
+                events = self.selector.select(timeout=self.SOCK_EVENT_TO)
+                if self.__stopEvent.is_set():  # may be set while waiting for selector events (unlikely)
+                    break
+                for _, mask in events:
+                    if (mask & selectors.EVENT_READ):
+                        for line in self.__buffered_readLine():
+                            Timer(0, self.__onReceiveCallback, args=[line]).start()
+                            Timer(0, self.__onAllMessage, args=[line]).start()
+                    if (mask & selectors.EVENT_WRITE):
+                        self.__write()
+                # Sleep for period or until there is data in the write buffer.
+                # In theory if data is constantly avaiable, this could block,
+                # in which case it may be better to self.__stopEvent.wait()
+                if self.__dataReadyEvent.wait(self.SLEEP_PERIOD):
+                    continue
+                continue
         except Exception as e:
-            print(e)
-            if 'timed out' or "[WinError 10054]" or '[WinError 10038]' in str(e):
-                Timer(0, self.__onReceiveCallback, args=[b'{"type":"closePlugin"}']).start()
-                pass
+            self.__die(f"Exception in client event loop: {repr(e)}", e)
 
     def __onReceiveCallback(self, rawData: bytes):
         data = json.loads(rawData.decode())
@@ -69,6 +114,57 @@ class Client(EventEmitter):
     def __onAllMessage(self, rawData):
         data = json.loads(rawData.decode())
         self.emit(TYPES.allMessage, self.client, data)
+
+    def __open(self):
+        try:
+            self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.selector = selectors.DefaultSelector()
+            self.client.connect((self.TPHOST, self.TPPORT))
+        except Exception:
+            self.selector = self.client = None
+            raise
+        self.client.setblocking(False)
+        self.selector.register(self.client, (selectors.EVENT_READ | selectors.EVENT_WRITE))
+        self.__stopEvent.clear()
+
+    def __close(self):
+        self.__stopEvent.set()
+        if self.__writeLock.locked():
+            self.__writeLock.release()
+        self.__sendBuffer.clear()
+        if not self.client:
+            return
+        if self.selector.get_map():
+            try:
+                self.selector.unregister(self.client)
+            except Exception as e:
+                print(f"Error in selector.unregister(): {repr(e)}")
+        try:
+            self.client.shutdown(socket.SHUT_RDWR)
+            self.client.close()
+        except OSError as e:
+            print(f"Error in socket.close(): {repr(e)}")
+        finally:
+            # Delete reference to socket object for garbage collection, socket cannot be reused anyway.
+            self.client = None
+        self.selector.close()
+        self.selector = None
+        # print("TP Client stopped.")
+
+    def __die(self, msg=None, exc=None):
+        if msg: print(msg)
+        Timer(0, self.__onReceiveCallback, args=[b'{"type":"closePlugin"}']).start()
+        self.__close()
+        if exc: raise exc
+
+    def __getWriteLock(self):
+        if self.__writeLock.acquire(timeout=15):
+            if self.__stopEvent.is_set():
+                if self.__writeLock.locked(): self.__writeLock.release()
+                return False
+            return True
+        self.__die(exc=RuntimeError("Send buffer mutex deadlock, cannot continue."))
+        return False
 
     def isActionBeingHeld(self, actionId):
         return actionId in self.__heldActions
@@ -123,33 +219,36 @@ class Client(EventEmitter):
         '''
         self.send({"type": "updateActionData", "instanceId": instanceId, "data": {"minValue": minValue, "maxValue": maxValue, "id": stateId, "type": "number"}})
 
-
     def send(self, data):
         '''
         This manages the massage to send
         '''
-        self.client.sendall((json.dumps(data)+'\n').encode())
-
+        if self.__getWriteLock():
+            if len(self.__sendBuffer) + len(data) > self.SND_BUFFER_SZ:
+                self.__writeLock.release()
+                raise ResourceWarning("TP Client send buffer is full!")
+            self.__sendBuffer += (json.dumps(data)+'\n').encode()
+            self.__writeLock.release()
+            self.__dataReadyEvent.set()
 
     def connect(self):
         '''
-        This is mainly used for connecting to TP Server
+        This is mainly used for connecting to TP Server.
+        If successful, it starts the main processing loop of this client.
+        Does nothing if client is already connected.
         '''
-        try:
-            self.client.connect((self.TPHOST, self.TPPORT))
-            self.__running = True
-        except ConnectionRefusedError:
-            raise Exception("Failed to connect to TouchPortal")
-        self.send({"type":"pair", "id": self.pluginId})
-        self.__parseReceiveData()
+        if self.__stopEvent.is_set():
+            self.__open()
+            self.send({"type":"pair", "id": self.pluginId})
+            self.__run()  # start the event loop
 
     def disconnect(self):
         '''
-        This closes the Socket
+        This closes the connection to TP and terminates the client processing loop.
+        Does nothing if client is already disconnected.
         '''
-        self.client.shutdown(1)
-        self.client.close()
-        self.__running = False
+        if not self.__stopEvent.is_set():
+            self.__close()
 
 
 class Tools():


### PR DESCRIPTION
Hi Damien,

If you're interested, I re-wrote the I/O parts to use Python `selectors` and non-blocking sockets.  The API has been a great help, I just didn't love how it blocked while waiting for data (hard to interrupt it cleanly).  But changing that called for a new approach (or that's what I chose, anyway).  It's a fairly major refactor, and I would urge testing with your own plugins of course, and if you don't want to merge I totally understand.  Just wanted to run it by you.

The first commit in the series just bring it up to the same code as on PyPi (if you push those to GH, I can refactor based on them).  2nd is just some minor cleanup, and the actual refactoring is in the newest commit.

I set it up so when data is ready to be written _to_ TP, it should go out with no delay (essentially like the `sendAll()` which was there before).  But there is a short sleep between reads from TP (`SLEEP_PERIOD` constant), which is obviously different from your version.  But, anecdotally (I have no actual performance benchmarks), the client now seems more responsive (or rather my plugin does, which is using the client).  YMMV as they say  :)

I only commented a few key points, so if anything is unclear, just say so.   I chose to be fairly "paranoid" in the code so there are a few sanity checks which may not be strictly necessary (like the input buffer limit).

BTW in case it's not obvious, I'm the max.paperno you chatted with briefly in Discord plugins room.   I'll also be publishing my plugin soon, though it's fairly esoteric... I'm using it to view all the macros programmed into my Logitech keyboard and mouse for my various applications (up to 60 mapping per app... I can never remember most of them). So now all the right macros show up automagically on TP whenever I switch apps (plus whatever other buttons I want to put on the TP pages for those apps). 

Here's how I'm running the client, from `main()` of my plugin, on the same main thread.  I have another thread running which watches a folder for changes and does some callbacks. It all works quite well together.

```python
  try:
    TPClient.connect()  # blocking
  except KeyboardInterrupt:
    # exit gracefully when testing interactively
    log.warn("Caught keyboard interrupt, exiting.")
  except Exception:
    # anything raised by the TP Client I/O (not the event handler callbacks) should show up here
    log.err(f"Exception in TP client.\n{traceback.format_exc()}")
  finally:
    TPClient.disconnect()  # make sure it's stopped, no-op if alredy stopped.
  # TP disconnected, clean up... join other thread(s), etc.
```

Cheers,
-Max