### PR TITLE
Argument type validation improvements and new conveniences.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ TPClient = TouchPortalAPI.Client('YourPluginID') # Initiate the client (replace 
 
 @TPClient.on('info')  # This Will run once You've connected to TouchPortal
 def OnStart(client, data):
-    # You must provide 2 parm in the function or else it will give error 
+    # You must provide 2 parm in the function or else it will give error
     print('I am Connected!', data)
-    
-    
+
+
     TPClient.stateUpdate("(Your State ID)", "State Value") # This if you want to update a dymic states in TouchPortal
-    
+
     updateStates = [
         {
             "id": "(Your State ID)",
@@ -30,7 +30,7 @@ def OnStart(client, data):
         }
     ]
     TPClient.stateUpdateMany(updateStates) # Or You can create an list with however many state you want and use this function to send them all
-    
+
 @TPClient.on('action')  # This manages when you press a button in TouchPortal it will send here in json format
 def Actions(client, data):
     print(data)
@@ -38,13 +38,13 @@ def Actions(client, data):
 @TPClient.on('settings') # This Function will get called Everytime when someone changes something in your plugin settings
 def Settings(client, data):
     print('received data from settings!')
-    
+
 @TPClient.on('closePlugin') # When TouchPortal sends close Plugin message it will run this function
 def shutDown(client, data):
     print('Received shutdown message!')
     TPClient.disconnect() # This is how you disconnect once you received the closePlugin message
-    
-    
+
+
 TPClient.connect() # Connect to Touch Portal
 
 ```
@@ -86,27 +86,37 @@ and there is another class in this API which is called TYPES it has all the type
 
 ## List of Methods
 - isActionBeingHeld(actionId)
-  - This returns True or False for a Action ID If you have an Action that can be held And When you hold it, Then This would be True
-- createStates(stateId, description, value)
-  - This will create a States in runtime stateId, description, value are all Required
+  - This returns `True` or `False` for an Action ID. If you have an Action that can be held, this nethod would return `True` while it is being held, and `False` otherwise.
+- createState(stateId, description, value)
+  - This will create a TP State at runtime. `stateId`, `description`, and `value` are all required (`value` becomes the State's default value).
+  If the State already exists, it will be updated with `value` instead of being re-created.
+- createStateMany(stateId, states:list)
+  - Convenience function to create several States at once. `states` should be an iteratable of `dict` types in the form of `{'id': "StateId", 'desc': "Description", 'value': "Default Value"}`.
 - removeState(stateId)
-  - This removes a States that has been created in RunTime. StateId needs to be a string
+  - This removes a State that has been created at runtime. `stateId` needs to be a string.
+- removeStateMany(states)
+  - Convenience function to remove several States at once. `states` should be an iteratable of state ID strings.
+- choiceUpdate(stateId, values)
+  - This updates the list of choices in a previously-declared TP State with id `stateId`. See TP API reference for details on updating list values.
 - choiceUpdateSpecific(stateId, values, instanceId)
-  - This Updates a Specific Item in the drop Down menu
+  - This updates a list of choices in a specific TP Item Instance, specified in `instanceId`. See TP API reference for details on updating specific instances.
 - settingUpdate(settingName, settingValue)
-  - This updates a value in Your Plugin Settings.
+  - This updates a value in your plugin's Settings.
 - stateUpdate(stateId, stateValue)
-  - This Updates a value in ether a pre created States or States created in RunTime
+  - This updates a value in ether a pre-defined static State or a dynamic State created in runtime.
 - stateUpdateMany(states)
-  - This is the same as `stateUpdate(stateId, stateValue)` but you can put in a list for example `TPClient.stateUpdateMany([{"id": "StateId", "value": "The New Value"}])` You can put as many as you want
-- updateActionData(instanceId, stateId, minValue, MaxValue)
-  - This allows you to update Action Data in one of your Action. Currently TouchPortal Only Supports data type Number
+  - Convenience function to update serveral states at once. `states` should be an iteratable of `dict` types in the form of `{'id': "StateId", 'value': "The New Value"}`.
+- updateActionData(instanceId, stateId, minValue, maxValue)
+  - This allows you to update Action Data in one of your Action. Currently TouchPortal only supports changing the minimum and maximum values in numeric data types.
 - send(data)
-  - Normally You dont need to Touch This but this is how It sends data to it If this API missing Anything from https://www.touch-portal.com/api/ you can still use this Library
-- Connect()
-  - This is When you have setup PluginID like `TPClient = TouchPortalAPI.Client("YourPluginID")` after all the callbacks and things are setup you can run this method normally this is used at the end of your script
+  - This will try to send any arbitrary Python object in `data` (presumably something `dict`-like) to TouchPortal after serializing it as JSON and adding a `\n`.
+  Normally there is no need to use this method directly, but if the Python API doesn't cover something from the TP API, this could be used instead.
+- connect()
+  - Call this method to connect to TouchPortal after all your setups are complete. Normally this is used at the end of your script.
+  Does nothing if the client is already connected.
 - disconnect()
-  - This is how you shutDown your Plugin normally is used in `@TPClient.on("closePlugin")` callback but it can be used any way you like only after you've connected to TouchPortal
+  - Trigger the client to disconnect from TouchPortal. Normally this is used in `@TPClient.on("closePlugin")` callback but it can be used any way you like only
+  after you've connected to TouchPortal. Does nothing if client is not currently connected.
 
 ## Touch Portal api documentation
 https://www.touch-portal.com/api

--- a/TouchPortal-API/TouchPortalAPI/__init__.py
+++ b/TouchPortal-API/TouchPortalAPI/__init__.py
@@ -175,12 +175,29 @@ class Client(EventEmitter):
             else:
                 self.stateUpdate(stateId, value)
 
+    def createStateMany(self, states:list):
+        try:
+            for state in states:
+                if isinstance(state, dict):
+                    self.createState(state.get('id', ""), state.get('desc', ""), state.get('value', ""))
+                else:
+                    raise TypeError(f'createStateMany() requires a list of dicts, got {type(state)} instead.')
+        except:
+            raise TypeError(f'createStateMany() requires an iteratable, got {type(states)} instead.')
+
     def removeState(self, stateId:str, validateExists = True):
         if stateId and stateId in self.currentStates:
             self.send({"type": "removeState", "id": stateId})
             self.currentStates.pop(stateId)
         elif validateExists:
             raise Exception(f"{stateId} Does not exist.")
+
+    def removeStateMany(self, states:list):
+        try:
+            for state in states:
+                self.removeState(state, False)
+        except TypeError:
+            raise TypeError(f'removeStateMany() requires an iteratable, got {type(states)} instead.')
 
     def choiceUpdate(self, choiceId:str, values:list):
         if choiceId:


### PR DESCRIPTION
You may like these changes which add a little efficiency to the API, but also some more error checking.  

I kept the checking you already had (except for now allowing blank `value` for a State), and added a couple more, while also making things like dict lookups safer. But I'm not really sure some of the checks which raise errors add that much value... since they raise errors anyway, the only real advantage to a user is that the error messages are more specific than generic Python.  But in the end the API user would still need to trap those errors anyway (or crash).  And the disadvantage is a slightly slower API with more lines of code.

I'll put some more comments in the code.

Thanks,
-Max