### PR TITLE
Update client.py

### DIFF
--- a/TouchPortalAPI/client.py
+++ b/TouchPortalAPI/client.py
@@ -423,8 +423,7 @@ class Client(ExecutorEventEmitter):
         
         if choiceId:
             if isinstance(values, list):
-                if self.choiceUpdateList.get(choiceId) == values:
-                else:
+                if self.choiceUpdateList.get(choiceId) != values:
                     self.send({"type": "choiceUpdate", "id": choiceId, "value": values})
                     self.choiceUpdateList[choiceId] = values
             else:

--- a/TouchPortalAPI/client.py
+++ b/TouchPortalAPI/client.py
@@ -420,10 +420,13 @@ class Client(ExecutorEventEmitter):
         This updates the list of choices in a previously-declared TP State with id `stateId`.
         See TP API reference for details on updating list values.
         """
+        
         if choiceId:
             if isinstance(values, list):
-                self.send({"type": "choiceUpdate", "id": choiceId, "value": values})
-                self.choiceUpdateList[choiceId] = values
+                if self.choiceUpdateList.get(choiceId) == values:
+                else:
+                    self.send({"type": "choiceUpdate", "id": choiceId, "value": values})
+                    self.choiceUpdateList[choiceId] = values
             else:
                 self.__raiseException(f'choiceUpdate() values argument needs to be a list not a {type(values)}')
 


### PR DESCRIPTION
Added a check in `choiceUpdate` to see if the values are equal to that already saved
if so it will not update the choicelist
This will stop it from 'erasing' the active input when user is editing an action.

Example: 

If the plugin does a choiceupdate then it will erase this list, even though its 100% identical.. 
with the change mentioned this will no longer happen  
![image](https://user-images.githubusercontent.com/76603653/213924744-4c7f3224-2e52-42f2-83e1-56c9390ee8c4.png)
